### PR TITLE
Show SCSS errors when refusing to compile stylint.

### DIFF
--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -173,6 +173,8 @@ let webpackConfig = {
     }),
     new StyleLintPlugin({
       failOnError: !config.enabled.watcher,
+      emitErrors: true,
+      quiet: false,
       syntax: 'scss',
     }),
     new FriendlyErrorsWebpackPlugin(),


### PR DESCRIPTION
As per [Roots Discourse](https://discourse.roots.io/t/yarn-build-failed-because-of-a-stylelint-error/9792/13).

Thought it might help and wouldn't hurt.